### PR TITLE
Add Chrono break (delete)  , dump_to_jsonl, and other cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.xz
 build/
 .vscode/
+logfiles/
+logdb/
+*.txt
+log_example

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build/
 logfiles/
 logdb/
 *.txt
+*.jsonl
 log_example

--- a/ChronobreakFilter.cpp
+++ b/ChronobreakFilter.cpp
@@ -1,16 +1,13 @@
 #include "ChronobreakFilter.h"
+#include "Key.h"
 
 ChronobreakFilter::ChronobreakFilter() {}
 
 bool ChronobreakFilter::Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value,
                                 std::string* new_value, bool* value_changed) const {
-  std::string key_str = key.ToString();
-  std::regex pattern(R"(\d+,\s*(\d+),)");
-  std::smatch match;
 
-  if (!std::regex_search(key_str, match, pattern)) return false;
+  int64_t timestamp =std::get<1>(deserializeKey(key));
 
-  int64_t timestamp = std::stoll(match[1]);
   int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                      std::chrono::system_clock::now().time_since_epoch()).count();
 

--- a/ChronobreakFilter.cpp
+++ b/ChronobreakFilter.cpp
@@ -5,14 +5,14 @@ ChronobreakFilter::ChronobreakFilter() {}
 
 bool ChronobreakFilter::Filter(int level, const rocksdb::Slice& key, const rocksdb::Slice& value,
                                 std::string* new_value, bool* value_changed) const {
-
-  int64_t timestamp =std::get<1>(deserializeKey(key));
+  LogKey key_data=deserializeKey(key);
+  int64_t timestamp =std::get<1>(key_data);
 
   int64_t now_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                      std::chrono::system_clock::now().time_since_epoch()).count();
-
+  
   if (now_ms - timestamp > FIFTEEN_SEC_MS) {
-    std::cout << "[FILTER] Dropping key due to TTL_X: " << key.ToString() << std::endl;
+    std::cout << "[FILTER] Dropping key due to TTL_X: " << std::get<2>(key_data) << std::endl;
     return true;
   }
 

--- a/Key.cpp
+++ b/Key.cpp
@@ -2,29 +2,61 @@
 #include <cstring>
 #include <sstream>
 
-std::string serializeKey(const LogKey& key) {
-    std::string result;
+void fill_key(sessionid_t sessinid,timestamp_t timestamp,uint8_t * out){
+    EncodeFixed32BE(out,sessinid);
+    EncodeFixed32BE(out+sizeof(sessinid),timestamp);
+}
+
+void serializeKey(const LogKey& key,std::string& out) {
+    std::string& result=out;
     uint32_t session_id = std::get<0>(key);
     uint32_t timestamp = std::get<1>(key);
     const std::vector<uint8_t>& type = std::get<2>(key);
+    uint8_t buf[KEY_MIN_SIZE];
+    fill_key(session_id,timestamp,buf);
 
-    result.append(reinterpret_cast<const char*>(&session_id), sizeof(session_id));
-    result.append(reinterpret_cast<const char*>(&timestamp), sizeof(timestamp));
+    //result.append(reinterpret_cast<const char*>(&session_id), sizeof(session_id));
+    //result.append(reinterpret_cast<const char*>(&timestamp), sizeof(timestamp));
+    result.append(reinterpret_cast<const char*>(buf),sizeof(buf));
     result.append(reinterpret_cast<const char*>(type.data()), type.size());
 
-    return result;
 }
 
+std::string serializeKey(const LogKey& key) {
+    std::string result;
+    serializeKey(key,result);
+    return result;
+}
 LogKey deserializeKey(const std::string& raw) {
-    if (raw.size() < 8) {
+    if (raw.size() < KEY_MIN_SIZE) {
         throw std::runtime_error("Key too short to decode");
     }
 
     uint32_t session_id, timestamp;
-    std::memcpy(&session_id, raw.data(), 4);
-    std::memcpy(&timestamp, raw.data() + 4, 4);
+    //std::memcpy(&session_id, raw.data(), 4);
+    //std::memcpy(&timestamp, raw.data() + 4, 4);
+    auto ptr=reinterpret_cast<const uint8_t*>(raw.data());
+    session_id=DecodeFixed32BE(ptr);
+    timestamp=DecodeFixed32BE(ptr+4);
 
     std::vector<uint8_t> type(raw.begin() + 8, raw.end());
 
     return { session_id, timestamp, type };
+}
+LogKey deserializeKey(const rocksdb::Slice key){
+    if (key.size() < KEY_MIN_SIZE) {
+        throw std::runtime_error("Key too short to decode");
+    }
+
+    uint32_t session_id, timestamp;
+    //std::memcpy(&session_id, raw.data(), 4);
+    //std::memcpy(&timestamp, raw.data() + 4, 4);
+    auto ptr=reinterpret_cast<const uint8_t*>(key.data());
+    session_id=DecodeFixed32BE(ptr);
+    timestamp=DecodeFixed32BE(ptr+4);
+
+    std::vector<uint8_t> type(ptr + 8, ptr+key.size());
+
+    return { session_id, timestamp, type };
+
 }

--- a/Key.cpp
+++ b/Key.cpp
@@ -11,7 +11,7 @@ void serializeKey(const LogKey& key,std::string& out) {
     std::string& result=out;
     uint32_t session_id = std::get<0>(key);
     uint32_t timestamp = std::get<1>(key);
-    const std::vector<uint8_t>& type = std::get<2>(key);
+    auto type = std::get<2>(key);
     uint8_t buf[KEY_MIN_SIZE];
     fill_key(session_id,timestamp,buf);
 
@@ -39,7 +39,7 @@ LogKey deserializeKey(const std::string& raw) {
     session_id=DecodeFixed32BE(ptr);
     timestamp=DecodeFixed32BE(ptr+4);
 
-    std::vector<uint8_t> type(raw.begin() + 8, raw.end());
+    std::string type(raw.begin() + 8, raw.end());
 
     return { session_id, timestamp, type };
 }
@@ -55,7 +55,7 @@ LogKey deserializeKey(const rocksdb::Slice key){
     session_id=DecodeFixed32BE(ptr);
     timestamp=DecodeFixed32BE(ptr+4);
 
-    std::vector<uint8_t> type(ptr + 8, ptr+key.size());
+    std::string type(ptr + 8, ptr+key.size());
 
     return { session_id, timestamp, type };
 

--- a/Key.h
+++ b/Key.h
@@ -8,7 +8,7 @@
 
 using timestamp_t=uint32_t;
 using sessionid_t=uint32_t;
-using LogKey = std::tuple<sessionid_t,timestamp_t, std::vector<uint8_t>>;
+using LogKey = std::tuple<sessionid_t,timestamp_t, std::string>;
 const int KEY_MIN_SIZE=8;
 static_assert(KEY_MIN_SIZE==sizeof(sessionid_t)+sizeof(timestamp_t));
 static_assert(sizeof(sessionid_t)==4);

--- a/Key.h
+++ b/Key.h
@@ -3,8 +3,20 @@
 #include <vector>
 #include <string>
 #include <cstdint>
+#include <rocksdb/slice.h>
+#include "bit_utils.h"
 
-using LogKey = std::tuple<int64_t, int64_t, std::vector<uint8_t>>;
+using timestamp_t=uint32_t;
+using sessionid_t=uint32_t;
+using LogKey = std::tuple<sessionid_t,timestamp_t, std::vector<uint8_t>>;
+const int KEY_MIN_SIZE=8;
+static_assert(KEY_MIN_SIZE==sizeof(sessionid_t)+sizeof(timestamp_t));
+static_assert(sizeof(sessionid_t)==4);
+static_assert(sizeof(timestamp_t)==4);
 
 std::string serializeKey(const LogKey& key);
+void serializeKey(const LogKey & key,std::string& out);
 LogKey deserializeKey(const std::string& key);
+LogKey deserializeKey(const ROCKSDB_NAMESPACE::Slice key);
+
+void fill_key(sessionid_t sessinid,timestamp_t timestamp,uint8_t * out);

--- a/LogDB.cpp
+++ b/LogDB.cpp
@@ -105,6 +105,9 @@ timestamp_t LogDB::lastTimeStamp(sessionid_t sessionid){
 
 rocksdb::Status LogDB::ChronoBreak(sessionid_t sessionid,timestamp_t rollback_diff){
     timestamp_t last_timestamp=lastTimeStamp(sessionid);
+    if(rollback_diff>last_timestamp){
+        return ChronoBreakAbsolute(sessionid,0);
+    }
     return ChronoBreakAbsolute(sessionid,last_timestamp-rollback_diff);
 }
 

--- a/LogDB.h
+++ b/LogDB.h
@@ -1,17 +1,27 @@
 #pragma once
 #include <rocksdb/db.h>
-#include "LogRecord.h"
 #include "Key.h"
+#include "LogDBIterator.h"
 
 class LogDB {
 public:
+
     explicit LogDB(const std::string& path);
     ~LogDB();
+    timestamp_t lastTimeStamp(sessionid_t sessionid);
+    rocksdb::Status ChronoBreak(sessionid_t sessionid,timestamp_t rollback_diff);
+    rocksdb::Status ChronoBreakAbsolute(sessionid_t sessionid,timestamp_t rollback_time);
 
     void store(const LogKey& key, const std::string& rawLine);
     void read(const LogKey& key);
-    void compact();
+    
+    std::string ReadMSGPack(const LogKey& key);
 
+    LogDBIterator * NewIterator();
+    LogDBBoundedIterator * NewBoundedIterator(sessionid_t sessionid);
+
+    void compact();
+    
 private:
     rocksdb::DB* db_ = nullptr;
 };

--- a/LogDBIterator.h
+++ b/LogDBIterator.h
@@ -1,0 +1,90 @@
+#include <rocksdb/iterator.h>
+#include "Key.h"
+#include <nlohmann/json.hpp>
+
+struct LogDBIterator{
+    friend class LogDB;
+public:
+
+    virtual ~LogDBIterator()
+    {
+        delete it;
+    }
+    bool Valid()
+    {
+        return it->Valid();
+    }
+    void Next()
+    {
+        return it->Next();
+    }
+    void Prev()
+    {
+        return it->Prev();
+    }
+    virtual void SeekToFirst()
+    {
+        it->SeekToFirst();
+    }
+    virtual void SeekToLast()
+    {
+        it->SeekToLast();
+    }
+
+    rocksdb::Status status()
+    {
+        return it->status();
+    }
+    LogKey key()
+    {
+        return deserializeKey(it->key());
+    }
+
+    rocksdb::Slice valueMSGPack()
+    {
+        return it->value();
+    }
+    nlohmann::json valueJSONDocument()
+    {
+        auto val = it->value();
+        return nlohmann::json::from_msgpack(val.data(), val.data() + val.size());
+    }
+
+protected:
+    explicit LogDBIterator(rocksdb::Iterator *iter): it(iter) {}
+    rocksdb::Iterator *it;
+    LogDBIterator():it(nullptr) {}
+};
+struct LogDBBoundedIterator : LogDBIterator
+{
+    friend class LogDB;
+public:
+    virtual void SeekToFirst()
+    {
+        it->Seek(begin_key);
+    }
+    virtual void SeekToLast()
+    {
+        it->SeekForPrev(end_key);
+    }
+
+protected:
+    char begin_key_guard[KEY_MIN_SIZE],end_key_guard[KEY_MIN_SIZE];
+    rocksdb::Slice begin_key, end_key;
+    LogDBBoundedIterator(rocksdb::DB *db,
+                         sessionid_t start_sessionid,
+                         sessionid_t end_sessionid):
+        begin_key(begin_key_guard, KEY_MIN_SIZE),
+        end_key(end_key_guard, KEY_MIN_SIZE)
+    {
+        fill_key(start_sessionid, 0, reinterpret_cast<uint8_t *>(begin_key_guard));
+        fill_key(end_sessionid + 1, 0, reinterpret_cast<uint8_t *>(end_key_guard));
+
+        rocksdb::ReadOptions read_option=rocksdb::ReadOptions();
+        read_option.iterate_lower_bound = &begin_key;
+        read_option.iterate_upper_bound = &end_key;
+        it = db->NewIterator(read_option);
+    }
+    LogDBBoundedIterator(rocksdb::DB * db,
+                         sessionid_t sessinid):LogDBBoundedIterator(db, sessinid, sessinid) {}
+};

--- a/LogRecord.h
+++ b/LogRecord.h
@@ -1,9 +1,0 @@
-#pragma once
-#include <string>
-#include <msgpack.hpp>
-
-struct LogRecord {
-    std::string raw_line;
-
-    MSGPACK_DEFINE(raw_line);
-};

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -D_GLIBCXX_USE_CXX11_ABI=1 -I. -Inlohmann -Irocksdb-main/include
+CXXFLAGS = -std=c++17 -Wall -D_GLIBCXX_USE_CXX11_ABI=1 -I. -Inlohmann -Irocksdb-main/include -fno-rtti
 
-LDFLAGS = rocksdb-main/librocksdb.a -lmsgpackc -lpthread -lz -lbz2 -lsnappy -llz4 -lzstd
+LDFLAGS = -lrocksdb -lpthread -lz -lbz2 -lsnappy -llz4 -lzstd
 
 SRC = main.cpp LogDB.cpp ChronobreakFilter.cpp Key.cpp
 TARGET = log_example

--- a/bit_utils.h
+++ b/bit_utils.h
@@ -1,0 +1,36 @@
+#pragma once
+#include <cstdint>
+#include <cstring>
+
+inline void EncodeFixed32BE(uint8_t * buf, uint32_t value) {
+    buf[0] = (value >> 24) & 0xff;
+    buf[1] = (value >> 16) & 0xff;
+    buf[2] = (value >> 8) & 0xff;
+    buf[3] = value & 0xff;
+}
+
+inline void EncodeFixed64BE(uint8_t * buf, uint64_t value) {
+    buf[0] = (value >> 56) & 0xff;
+    buf[1] = (value >> 48) & 0xff;
+    buf[2] = (value >> 40) & 0xff;
+    buf[3] = (value >> 32) & 0xff;
+    buf[4] = (value >> 24) & 0xff;
+    buf[5] = (value >> 16) & 0xff;
+    buf[6] = (value >> 8) & 0xff;
+    buf[7] = value & 0xff;
+
+}
+inline uint32_t DecodeFixed32BE(const uint8_t * ptr) {
+    return ((static_cast<uint32_t>((ptr[0])) << 24)|
+            (static_cast<uint32_t>((ptr[1])) << 16)|
+            (static_cast<uint32_t>((ptr[2])) << 8) |
+			(static_cast<uint32_t>((ptr[3]))));
+
+}
+
+inline uint64_t DecodeFixed64BE(const uint8_t* ptr) {
+    uint64_t hi = DecodeFixed32BE(ptr);
+    uint64_t lo = DecodeFixed32BE(ptr+4);
+    return (hi << 32) | lo;
+}
+

--- a/db_utils.h
+++ b/db_utils.h
@@ -1,0 +1,29 @@
+#pragma once
+#include "LogDB.h"
+#include <nlohmann/json.hpp>
+#include <iomanip>
+
+void dump_iterator(LogDBIterator *it, std::ofstream &out){
+  for (it->SeekToFirst(); it->Valid(); it->Next()){
+    LogKey key = it->key();
+    out<<"{\"" << std::get<0>(key) << ',' << std::get<1>(key) << ',';
+    auto type = std::get<2>(key);
+    for(auto i:type){
+      out<<static_cast<char>(i);
+    }
+    out<<"\":";
+    out << it->valueJSONDocument();
+    out << "}\n";
+  }
+  delete it;
+}
+
+void dump_to_jsonl(LogDB *db, sessionid_t sessionid, std::ofstream &out){
+  auto it = db->NewBoundedIterator(sessionid);
+  dump_iterator(it, out);
+}
+
+void dump_to_jsonl(LogDB *db, std::ofstream &out){
+  auto it = db->NewIterator();
+  dump_iterator(it, out);
+}


### PR DESCRIPTION
어차피 key의 2번째 type부분은 항상 string일테니 더 로그 등에 출력하기 편한 std::string 형식을 사용하게 하였습니다.
